### PR TITLE
Add more projects to Using-wsldl.md

### DIFF
--- a/Using-wsldl.md
+++ b/Using-wsldl.md
@@ -3,17 +3,22 @@ title: "Project List Using wsldl"
 ---
 # Project List Using wsldl
 List of projects using the official build of wsldl.
+⭐ used to show recommended project if a distro has multiple projects
 
 ## Distros
 [AlmaLinux](https://github.com/amithgeorge/AlmaLinux-WSL2) (by [amithgeoge](https://github.com/amithgeorge))
 
-[Alpine Linux](https://github.com/yuk7/AlpineWSL) (by [yuk7](https://github.com/yuk7))
+⭐ [Alpine Linux](https://github.com/yuk7/AlpineWSL) (by [yuk7](https://github.com/yuk7))
+
+[Alpine Linux Edge (Rolling Release)](https://github.com/sileshn/AlpineWSL2) (by [SileshNair](https://github.com/sileshn))
 
 [Alpine Linux with Git-LFS and Sphinx](https://github.com/binarylandscapes/AlpineWSL) (by [binarylandscapes](https://github.com/binarylandscapes))
 
 [Amazon Linux 2](https://github.com/yosukes-dev/AmazonWSL) (by [yosukes-dev](https://github.com/yosukes-dev))
 
 [Arch Linux](https://github.com/yuk7/ArchWSL) (by [yuk7](https://github.com/yuk7))
+
+⭐ [Arch Linux](https://github.com/sileshn/ArchWSL2) (by [SileshNair](https://github.com/sileshn))
 
 [Artix Linux](https://github.com/hdk5/ArtixWSL) (by [hdk5](https://github.com/hdk5))
 
@@ -29,11 +34,15 @@ List of projects using the official build of wsldl.
 
 [ElementaryOS](https://github.com/sileshn/ElementaryWSL2) (by [SileshNair](https://github.com/sileshn))
 
+[EndeavourOS](https://github.com/sileshn/EndeavourOSWSL2) (by [SileshNair](https://github.com/sileshn))
+
 [Fedora](https://github.com/yosukes-dev/FedoraWSL) (by [yosukes-dev](https://github.com/yosukes-dev))
 
 [Funtoo](https://github.com/rescenic/FuntooWSL) (by [rescenic](https://github.com/rescenic)) 
 
-[Gentoo](https://github.com/VPraharsha03/GentooWSL2) (by [VPraharsha03](https://github.com/VPraharsha03))
+⭐ [Gentoo](https://github.com/VPraharsha03/GentooWSL2) (by [VPraharsha03](https://github.com/VPraharsha03))
+
+[Gentoo](https://github.com/sileshn/GentooWSL2) (by [SileshNair](https://github.com/sileshn))
 
 [Linux Mint](https://github.com/sileshn/LinuxmintWSL2) (by [SileshNair](https://github.com/sileshn))
 
@@ -41,8 +50,12 @@ List of projects using the official build of wsldl.
 
 [Red hat(UBI)](https://github.com/yosukes-dev/RHWSL) (by [yosukes-dev](https://github.com/yosukes-dev))
 
+[Rhino Linux](https://github.com/sileshn/RhinoLinuxWSL2) (by [SileshNair](https://github.com/sileshn))
+
 [Rocky Linux](https://github.com/mishamosher/RL-WSL) (by [mishamosher](https://github.com/mishamosher))
 
 [Slackware](https://github.com/sileshn/SlackwareWSL2) (by [SileshNair](https://github.com/sileshn))
 
-[Void Linux](https://github.com/am11/VoidWSL) (by [am11](https://github.com/am11))
+[Solus](https://github.com/sileshn/SolusWSL2) (by [SileshNair](https://github.com/sileshn))
+
+[Void Linux (glibc and mucl variants)](https://github.com/am11/VoidWSL) (by [am11](https://github.com/am11))

--- a/Using-wsldl.md
+++ b/Using-wsldl.md
@@ -3,12 +3,11 @@ title: "Project List Using wsldl"
 ---
 # Project List Using wsldl
 List of projects using the official build of wsldl.
-⭐ used to show recommended project if a distro has multiple projects
 
 ## Distros
 [AlmaLinux](https://github.com/amithgeorge/AlmaLinux-WSL2) (by [amithgeoge](https://github.com/amithgeorge))
 
-⭐ [Alpine Linux](https://github.com/yuk7/AlpineWSL) (by [yuk7](https://github.com/yuk7))
+[Alpine Linux](https://github.com/yuk7/AlpineWSL) (by [yuk7](https://github.com/yuk7))
 
 [Alpine Linux Edge (Rolling Release)](https://github.com/sileshn/AlpineWSL2) (by [SileshNair](https://github.com/sileshn))
 
@@ -18,7 +17,7 @@ List of projects using the official build of wsldl.
 
 [Arch Linux](https://github.com/yuk7/ArchWSL) (by [yuk7](https://github.com/yuk7))
 
-⭐ [Arch Linux](https://github.com/sileshn/ArchWSL2) (by [SileshNair](https://github.com/sileshn))
+[Arch Linux](https://github.com/sileshn/ArchWSL2) (by [SileshNair](https://github.com/sileshn))
 
 [Artix Linux](https://github.com/hdk5/ArtixWSL) (by [hdk5](https://github.com/hdk5))
 
@@ -40,7 +39,7 @@ List of projects using the official build of wsldl.
 
 [Funtoo](https://github.com/rescenic/FuntooWSL) (by [rescenic](https://github.com/rescenic)) 
 
-⭐ [Gentoo](https://github.com/VPraharsha03/GentooWSL2) (by [VPraharsha03](https://github.com/VPraharsha03))
+[Gentoo](https://github.com/VPraharsha03/GentooWSL2) (by [VPraharsha03](https://github.com/VPraharsha03))
 
 [Gentoo](https://github.com/sileshn/GentooWSL2) (by [SileshNair](https://github.com/sileshn))
 


### PR DESCRIPTION
- Added star (⭐) to recommended project when a distro has multiple
- Added more projects using wsldl
  - Alpine Linux Edge (Rolling Release)
  - Arch Linux
  - EndeavourOS
  - Gentoo
  - Rhino Linux
  - Solus

these projects also include New User creations scripts, the option to increase vhdx size from the default 256GB, and an empty wsl.conf file with all headers included

projects found by searching github with `(path:**/README.md OR path:**/readme.md) wsldl`